### PR TITLE
Fix build on Xenial (GCC 5)

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -5,6 +5,9 @@ remake_define(CPC_LIB_COMPAT_MODE ON
 remake_define(CAN_MAX_DEVICE 10
   CACHE STRING "The maximum number of CPC CAN devices.")
 
+# The -fgnu89-inline directive is needed to correctly interpret inlined functions in ethercan.c 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fgnu89-inline")
+
 remake_add_library(cpc PREFIX OFF)
 remake_add_headers(
   cpc.h


### PR DESCRIPTION
This is needed because GCC 5 switched the default C standard from 89 to 99, and 99 changes the inline keyword semantics. Without this change, build of ethercat.c fails with unresolved symbols for `hex_to_u8` and `u8_to_hex`.
